### PR TITLE
Call setup_app function to setup datastore client

### DIFF
--- a/main.py
+++ b/main.py
@@ -80,8 +80,8 @@ if os.path.isfile("./.env"):
     load_dotenv()
 
 load_config(app)
+setup_app(app)
 
 if __name__ == "__main__":
     print("Running Flask application")
-    setup_app(app)
     app.run(host="0.0.0.0", port=5011)


### PR DESCRIPTION
Minor issue when configuring the datastore client. 

GCP app engine runs the Flask application using [gunicorn](https://gunicorn.org/), which does not start the Flask app from the `if __name__ == "__main__":` function in `main.py`. So if you run the Flask app using:
```bash
gunicorn --bind 0.0.0.0:5000 main:app 
```
The datastore client is not setup. Meaning that `setup_app(app)` function was not called. So accessing the client like `current_app.call_history_client.get_call_history_report_status()` fails.

This PR just moves `setup_app(app)` to run after load_config.

