### PR TITLE
Added check for call_history_model around extracting cohorts and waves

### DIFF
--- a/models/call_history_model.py
+++ b/models/call_history_model.py
@@ -29,9 +29,9 @@ class CallHistory:
     def generate_questionnaire_details(self, questionnaire_name):
         self.questionnaire_name = questionnaire_name
         self.survey = questionnaire_name[0:3]
-        if self.survey == "LMS":
-            self.wave: int = int(questionnaire_name[len(questionnaire_name) - 1:])
-            self.cohort: str = questionnaire_name[len(questionnaire_name) - 3: -1]
+        if self.survey == "LMS" and questionnaire_name[- 1:].isnumeric():
+            self.wave = int(questionnaire_name[- 1:])
+            self.cohort = questionnaire_name[- 3: -1]
 
 
 @dataclass

--- a/tests/models/test_call_history_model.py
+++ b/tests/models/test_call_history_model.py
@@ -21,8 +21,8 @@ def test_generate_questionnaire_details_lms():
 
     assert call_history.questionnaire_name == "LMS2101_AA1"
     assert call_history.survey == "LMS"
-    assert call_history.cohort == "AA"
     assert call_history.wave == 1
+    assert call_history.cohort == "AA"
 
 
 def test_generate_questionnaire_details_opn():
@@ -45,8 +45,8 @@ def test_generate_questionnaire_details_opn():
 
     assert call_history.questionnaire_name == "OPN2101A"
     assert call_history.survey == "OPN"
-    assert call_history.cohort is None
     assert call_history.wave is None
+    assert call_history.cohort is None
 
 
 def test_cati_call_history_table_fields():
@@ -72,3 +72,27 @@ def test_cati_call_history_table_fields():
 
 def test_cati_call_history_table_table_name():
     assert CatiCallHistoryTable.table_name() == "cati.DialHistory"
+
+
+def test_generate_questionnaire_details_lms_dodgy_iterations():
+    call_history = CallHistory(
+        "896c4038-2b07-40bf-a853-ab07305ca3eb",
+        "1001041",
+        1,
+        1,
+        0,
+        "2021-05-12 13:10:03.4471819",
+        "2021-05-12 13:10:35.0991819",
+        31,
+        "Finished (No contact)",
+        "Edwin",
+        "Busy",
+        None,
+        None,
+    )
+    call_history.generate_questionnaire_details("LMS2202_TST")
+
+    assert call_history.questionnaire_name == "LMS2202_TST"
+    assert call_history.survey == "LMS"
+    assert call_history.wave is None
+    assert call_history.cohort is None


### PR DESCRIPTION
I did originally create a separate function to extract waves and cohorts but it seemed overkill unless more survey types needed them