### PR TITLE
test: add timeout for datastore emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,4 @@ test-integration:
 
 .PHONY: test
 ## Run the full suite of unit tests
-test: test-unit #test-integration
+test: test-unit test-integration

--- a/tests/reports/test_interviewer_call_history_report.py
+++ b/tests/reports/test_interviewer_call_history_report.py
@@ -5,7 +5,7 @@ import pytest
 from google.api_core.datetime_helpers import DatetimeWithNanoseconds
 
 from models.error_capture import BertException
-from functions.datastore_functions import get_call_history_records, get_questionnaires
+from functions.datastore_functions import get_call_history_records, get_datastore_records, get_questionnaires
 from tests.helpers.interviewer_call_history_helpers import entity_builder
 
 
@@ -142,229 +142,229 @@ def datastore_formatted_records(records):
     return [datastore_formatted_record(record) for record in records]
 
 
-# @pytest.mark.integration_test
-# def test_get_datastore_records_returns_records_for_all_tlas_when_no_tla_specified(records_in_datastore):
-#     lms_call_record = {
-#         "name": "name=100001-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
-#         "survey": "LMS",
-#     }
-#     opn_call_record = {
-#         "name": "name=100002-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
-#         "survey": "OPN",
-#     }
-#
-#     records = [lms_call_record, opn_call_record]
-#
-#     with records_in_datastore(records):
-#         result = get_datastore_records(
-#             "James",
-#             datetime.datetime(2021, 9, 22, 23, ),
-#             datetime.datetime(2022, 1, 26, 23, ),
-#             None,
-#             None)
-#
-#         expected = datastore_formatted_records([lms_call_record, opn_call_record])
-#
-#         result = [dict(r) for r in result]
-#
-#         assert result == expected
-#
-#
-# @pytest.mark.integration_test
-# def test_get_datastore_records_returns_expected_result_when_called_with_a_given_tla(records_in_datastore):
-#     lms_call_record = {
-#         "name": "name=100001-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
-#         "survey": "LMS",
-#     }
-#     opn_call_record = {
-#         "name": "name=100002-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
-#         "survey": "OPN",
-#     }
-#     records = [
-#         lms_call_record,
-#         opn_call_record,
-#     ]
-#     with records_in_datastore(records):
-#         result = get_datastore_records("James", datetime.datetime(2021, 9, 22, 23, ),
-#                                        datetime.datetime(2022, 1, 26, 23, ), "LMS", None)
-#
-#         expected = datastore_formatted_records([lms_call_record])
-#
-#         result = [dict(r) for r in result]
-#
-#         assert result == expected
-#
-#
-# @pytest.mark.integration_test
-# def test_get_datastore_records_returns_expected_result_when_called_with_given_questionnaires(
-#         records_in_datastore):
-#     questionnaire1_name = "LMS2101_AA1"
-#     questionnaire_call_record1 = {
-#         "name": "name=100001-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
-#         "survey": "LMS",
-#         "questionnaire_name": questionnaire1_name
-#     }
-#
-#     questionnaire2_name = "LMS2101_BB1"
-#     questionnaire_call_record2 = {
-#         "name": "name=100002-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 13, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 13, 47),
-#         "survey": "LMS",
-#         "questionnaire_name": questionnaire2_name
-#     }
-#
-#     questionnaire_call_record3 = {
-#         "name": "name=100003-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 14, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 14, 47),
-#         "survey": "OPN",
-#         "questionnaire_name": "OPN2101_CC1"
-#     }
-#
-#     records = [
-#         questionnaire_call_record1,
-#         questionnaire_call_record2,
-#         questionnaire_call_record3,
-#     ]
-#     with records_in_datastore(records):
-#         result = get_datastore_records("James",
-#                                        datetime.datetime(2021, 9, 22, 23, ),
-#                                        datetime.datetime(2022, 1, 26, 23, ),
-#                                        None,
-#                                        [questionnaire1_name, questionnaire2_name])
-#
-#         expected = datastore_formatted_records([questionnaire_call_record1, questionnaire_call_record2])
-#
-#         result = [dict(r) for r in result]
-#
-#         assert result == expected
-#
-#
-# @pytest.mark.integration_test
-# def test_get_datastore_records_returns_expected_result_when_called_with_given_questionnaires_sorted_by_time(
-#         records_in_datastore):
-#     first_call_record = {
-#         "name": "name=100003-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
-#         "survey": "OPN",
-#         "questionnaire_name": "OPN2101_CC1"
-#     }
-#     second_call_record = {
-#         "name": "name=100002-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 13, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 13, 47),
-#         "survey": "LMS",
-#         "questionnaire_name": "LMS2101_BB1"
-#     }
-#     third_call_record = {
-#         "name": "name=100001-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 14, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 14, 47),
-#         "survey": "LMS",
-#         "questionnaire_name": "LMS2101_AA1"
-#     }
-#     records = [
-#         third_call_record,
-#         second_call_record,
-#         first_call_record,
-#     ]
-#     with records_in_datastore(records):
-#         result = get_datastore_records("James", datetime.datetime(2021, 9, 22, 23, ),
-#                                        datetime.datetime(2022, 1, 26, 23, ), None, ["LMS2101_AA1", "LMS2101_BB1"])
-#
-#         expected = datastore_formatted_records([
-#             second_call_record,
-#             third_call_record
-#         ])
-#
-#         result = [dict(r) for r in result]
-#
-#         assert result == expected
-#
-#
-# @pytest.mark.integration_test
-# def test_get_datastore_records_returns_expected_result_when_called_with_multiple_interviewers(records_in_datastore):
-#     james_call_record = {
-#         "name": "name=100001-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
-#         "survey": "LMS",
-#     }
-#     el_call_record = {
-#         "name": "name=100002-2022-01-25 12:45:03",
-#         "interviewer": "El",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
-#         "survey": "LMS",
-#     }
-#     records = [
-#         james_call_record,
-#         el_call_record,
-#     ]
-#     with records_in_datastore(records):
-#         result = get_datastore_records("James", datetime.datetime(2021, 9, 22, 23, ),
-#                                        datetime.datetime(2022, 1, 26, 23, ), None, None)
-#
-#         expected = datastore_formatted_records([james_call_record])
-#
-#         result = [dict(r) for r in result]
-#
-#         assert result == expected
-#
-#
-# @pytest.mark.integration_test
-# def test_get_datastore_records_returns_expected_result_when_called_with_calls_outside_of_date_range(
-#         records_in_datastore):
-#     search_start_date = datetime.datetime(2021, 9, 22, 23)
-#     search_end_date = datetime.datetime(2021, 9, 26, 23)
-#     call_record_before_start_date = {
-#         "name": "name=100002-2022-01-25 12:45:03",
-#         "interviewer": "El",
-#         "call_start_time": datetime.datetime(2021, 1, 25, 12, 45),
-#         "call_end_time": datetime.datetime(2021, 1, 25, 12, 47),
-#         "survey": "LMS",
-#     }
-#     call_record_after_end_date = {
-#         "name": "name=100001-2022-01-25 12:45:03",
-#         "interviewer": "James",
-#         "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
-#         "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
-#         "survey": "LMS",
-#     }
-#     records = [
-#         call_record_after_end_date,
-#         call_record_before_start_date,
-#     ]
-#     with records_in_datastore(records):
-#         result = get_datastore_records("James", search_start_date,
-#                                        search_end_date, None, None)
-#
-#         expected = []
-#
-#         assert result == expected
+@pytest.mark.integration_test
+def test_get_datastore_records_returns_records_for_all_tlas_when_no_tla_specified(records_in_datastore):
+    lms_call_record = {
+        "name": "name=100001-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
+        "survey": "LMS",
+    }
+    opn_call_record = {
+        "name": "name=100002-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
+        "survey": "OPN",
+    }
+
+    records = [lms_call_record, opn_call_record]
+
+    with records_in_datastore(records):
+        result = get_datastore_records(
+            "James",
+            datetime.datetime(2021, 9, 22, 23, ),
+            datetime.datetime(2022, 1, 26, 23, ),
+            None,
+            None)
+
+        expected = datastore_formatted_records([lms_call_record, opn_call_record])
+
+        result = [dict(r) for r in result]
+
+        assert result == expected
+
+
+@pytest.mark.integration_test
+def test_get_datastore_records_returns_expected_result_when_called_with_a_given_tla(records_in_datastore):
+    lms_call_record = {
+        "name": "name=100001-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
+        "survey": "LMS",
+    }
+    opn_call_record = {
+        "name": "name=100002-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
+        "survey": "OPN",
+    }
+    records = [
+        lms_call_record,
+        opn_call_record,
+    ]
+    with records_in_datastore(records):
+        result = get_datastore_records("James", datetime.datetime(2021, 9, 22, 23, ),
+                                       datetime.datetime(2022, 1, 26, 23, ), "LMS", None)
+
+        expected = datastore_formatted_records([lms_call_record])
+
+        result = [dict(r) for r in result]
+
+        assert result == expected
+
+
+@pytest.mark.integration_test
+def test_get_datastore_records_returns_expected_result_when_called_with_given_questionnaires(
+        records_in_datastore):
+    questionnaire1_name = "LMS2101_AA1"
+    questionnaire_call_record1 = {
+        "name": "name=100001-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
+        "survey": "LMS",
+        "questionnaire_name": questionnaire1_name
+    }
+
+    questionnaire2_name = "LMS2101_BB1"
+    questionnaire_call_record2 = {
+        "name": "name=100002-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 13, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 13, 47),
+        "survey": "LMS",
+        "questionnaire_name": questionnaire2_name
+    }
+
+    questionnaire_call_record3 = {
+        "name": "name=100003-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 14, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 14, 47),
+        "survey": "OPN",
+        "questionnaire_name": "OPN2101_CC1"
+    }
+
+    records = [
+        questionnaire_call_record1,
+        questionnaire_call_record2,
+        questionnaire_call_record3,
+    ]
+    with records_in_datastore(records):
+        result = get_datastore_records("James",
+                                       datetime.datetime(2021, 9, 22, 23, ),
+                                       datetime.datetime(2022, 1, 26, 23, ),
+                                       None,
+                                       [questionnaire1_name, questionnaire2_name])
+
+        expected = datastore_formatted_records([questionnaire_call_record1, questionnaire_call_record2])
+
+        result = [dict(r) for r in result]
+
+        assert result == expected
+
+
+@pytest.mark.integration_test
+def test_get_datastore_records_returns_expected_result_when_called_with_given_questionnaires_sorted_by_time(
+        records_in_datastore):
+    first_call_record = {
+        "name": "name=100003-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
+        "survey": "OPN",
+        "questionnaire_name": "OPN2101_CC1"
+    }
+    second_call_record = {
+        "name": "name=100002-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 13, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 13, 47),
+        "survey": "LMS",
+        "questionnaire_name": "LMS2101_BB1"
+    }
+    third_call_record = {
+        "name": "name=100001-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 14, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 14, 47),
+        "survey": "LMS",
+        "questionnaire_name": "LMS2101_AA1"
+    }
+    records = [
+        third_call_record,
+        second_call_record,
+        first_call_record,
+    ]
+    with records_in_datastore(records):
+        result = get_datastore_records("James", datetime.datetime(2021, 9, 22, 23, ),
+                                       datetime.datetime(2022, 1, 26, 23, ), None, ["LMS2101_AA1", "LMS2101_BB1"])
+
+        expected = datastore_formatted_records([
+            second_call_record,
+            third_call_record
+        ])
+
+        result = [dict(r) for r in result]
+
+        assert result == expected
+
+
+@pytest.mark.integration_test
+def test_get_datastore_records_returns_expected_result_when_called_with_multiple_interviewers(records_in_datastore):
+    james_call_record = {
+        "name": "name=100001-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
+        "survey": "LMS",
+    }
+    el_call_record = {
+        "name": "name=100002-2022-01-25 12:45:03",
+        "interviewer": "El",
+        "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
+        "survey": "LMS",
+    }
+    records = [
+        james_call_record,
+        el_call_record,
+    ]
+    with records_in_datastore(records):
+        result = get_datastore_records("James", datetime.datetime(2021, 9, 22, 23, ),
+                                       datetime.datetime(2022, 1, 26, 23, ), None, None)
+
+        expected = datastore_formatted_records([james_call_record])
+
+        result = [dict(r) for r in result]
+
+        assert result == expected
+
+
+@pytest.mark.integration_test
+def test_get_datastore_records_returns_expected_result_when_called_with_calls_outside_of_date_range(
+        records_in_datastore):
+    search_start_date = datetime.datetime(2021, 9, 22, 23)
+    search_end_date = datetime.datetime(2021, 9, 26, 23)
+    call_record_before_start_date = {
+        "name": "name=100002-2022-01-25 12:45:03",
+        "interviewer": "El",
+        "call_start_time": datetime.datetime(2021, 1, 25, 12, 45),
+        "call_end_time": datetime.datetime(2021, 1, 25, 12, 47),
+        "survey": "LMS",
+    }
+    call_record_after_end_date = {
+        "name": "name=100001-2022-01-25 12:45:03",
+        "interviewer": "James",
+        "call_start_time": datetime.datetime(2022, 1, 25, 12, 45),
+        "call_end_time": datetime.datetime(2022, 1, 25, 12, 47),
+        "survey": "LMS",
+    }
+    records = [
+        call_record_after_end_date,
+        call_record_before_start_date,
+    ]
+    with records_in_datastore(records):
+        result = get_datastore_records("James", search_start_date,
+                                       search_end_date, None, None)
+
+        expected = []
+
+        assert result == expected
 
 
 @patch("functions.datastore_functions.get_datastore_records")


### PR DESCRIPTION
The datastore emulator seems to be asynchronous; after adding or deleting entities it can take a few moments to take affect. The `RecordsInDatastore` helper now waits to confirm that each action has been successful.

Requires [RUN_DATABASE](https://github.com/ONSdigital/blaise-terraform/blob/main/ci/deploy-pipeline.yml#L1036) to be set to `TRUE`.